### PR TITLE
Added multiple parsing options for  specifying parameters

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,11 +7,12 @@
 --pre
 
 cached-property
+numpy
+parse
 
 # needed for functionality:
 jsonschema
 pandas
-numpy
 scipy
 
 # optional (could be removed with a small amount of work):

--- a/scisample/cross_product.py
+++ b/scisample/cross_product.py
@@ -7,11 +7,12 @@ import logging
 from contextlib import suppress
 
 from scisample.base_sampler import BaseSampler
+from scisample.utils import ParameterMixIn
 
 LOG = logging.getLogger(__name__)
 
 
-class CrossProductSampler(BaseSampler):
+class CrossProductSampler(BaseSampler, ParameterMixIn):
     """
     Class defining cross-product sampling.
 
@@ -85,7 +86,7 @@ class CrossProductSampler(BaseSampler):
 
         with suppress(KeyError):
             product_list.extend(
-                [value for key, value in self.data['parameters'].items()]
+                [value for key, value in self._parsed_parameters.items()]
             )
 
         sample_list = itertools.product(*product_list)

--- a/scisample/list.py
+++ b/scisample/list.py
@@ -6,12 +6,12 @@ import logging
 from contextlib import suppress
 
 from scisample.base_sampler import BaseSampler
-from scisample.utils import test_for_uniform_lengths
+from scisample.utils import test_for_uniform_lengths, ParameterMixIn
 
 LOG = logging.getLogger(__name__)
 
 
-class ListSampler(BaseSampler):
+class ListSampler(BaseSampler, ParameterMixIn):
     """
     Class defining basic list sampling.
 
@@ -49,7 +49,7 @@ class ListSampler(BaseSampler):
         self._check_variables_for_dups()
 
         with suppress(KeyError):
-            test_for_uniform_lengths(self.data['parameters'].items())
+            test_for_uniform_lengths(self._parsed_parameters.items())
 
     @property
     def parameters(self):
@@ -78,7 +78,7 @@ class ListSampler(BaseSampler):
         num_samples = 1
 
         with suppress(KeyError):
-            for key, value in self.data['parameters'].items():
+            for key, value in self._parsed_parameters.items():
                 num_samples = len(value)
                 break
 
@@ -89,7 +89,7 @@ class ListSampler(BaseSampler):
                 new_sample.update(self.data['constants'])
 
             with suppress(KeyError):
-                for key, value in self.data['parameters'].items():
+                for key, value in self._parsed_parameters.items():
                     new_sample[key] = value[i]
 
             self._samples.append(new_sample)

--- a/scisample/schema.py
+++ b/scisample/schema.py
@@ -30,6 +30,46 @@ def validate_sampler(sampler_data):
         SAMPLER_SCHEMA[sampler_data['type']]
         )
 
+PARAMETER_SCHEMA = {
+    'oneOf': [
+        {
+            'type': 'array'
+        },
+        {
+            'type': 'object',
+            'properties': {
+                'min': {'type': 'number'},
+                'max': {'type': 'number'},
+                'start': {'type': 'number'},
+                'stop': {'type': 'number'},
+                'step': {'type': 'number'},
+                'num_points': {'type': 'number'},
+            },
+            # Require defining each field once.
+            'allOf': [
+                {'oneOf':[
+                    {'required': ['min']},
+                    {'required': ['start']},
+                ]},
+                {'oneOf':[
+                    {'required': ['max']},
+                    {'required': ['stop']},
+                ]},
+                {'oneOf':[
+                    {'required': ['step']},
+                    {'required': ['num_points']},
+                ]},
+            ]
+        },
+        {
+            'type': 'string',
+            'anyOf': [
+                {'pattern': r'\[[0-9]*\.?[0-9]+:[0-9]*\.?[0-9]+:[0-9]*\.?[0-9]+\]'},
+                {'pattern': r'[0-9]*\.?[0-9]+ to [0-9]*\.?[0-9]+ by [0-9]*\.?[0-9]+'},
+            ]
+        }
+    ]
+}
 
 # @TODO: consider moving these schema into sampling files
 # Built-in schema
@@ -40,7 +80,7 @@ LIST_SCHEMA = {
         'constants': {'type': 'object'},
         'parameters': {
             'type': 'object',
-            'additionalProperties': {'type': 'array'}
+            'additionalProperties': PARAMETER_SCHEMA
         },
     },
     'required': ['type'],
@@ -64,7 +104,7 @@ CROSS_PRODUCT_SCHEMA = {
         'constants': {'type': 'object'},
         'parameters': {
             'type': 'object',
-            'additionalProperties': {'type': 'array'}
+            'additionalProperties': PARAMETER_SCHEMA
         },
     },
     'required': ['type'],

--- a/scisample/utils.py
+++ b/scisample/utils.py
@@ -174,7 +174,7 @@ def parse_parameters(data):
         return parameter_list(start, stop, step, num_points)
 
     if isinstance(data, str):
-        parse_formats = [
+        parse_formats = [git 
             '{start} to {stop} by {step}',
             '[{start}:{stop}:{step}]'
         ]
@@ -195,7 +195,7 @@ def parameter_list(start, stop, step=None, num_points=None):
 
     :param start: First point in the list
     :param stop: Last point in the list
-    :param step: Step size.  Will be ignored if step_size is
+    :param step: Step size.  Will be ignored if ``num_points`` is
         specified.
     :param num_points: Number of points.
     """

--- a/scisample/utils.py
+++ b/scisample/utils.py
@@ -174,7 +174,7 @@ def parse_parameters(data):
         return parameter_list(start, stop, step, num_points)
 
     if isinstance(data, str):
-        parse_formats = [git 
+        parse_formats = [
             '{start} to {stop} by {step}',
             '[{start}:{stop}:{step}]'
         ]

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,14 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.6',
-    install_requires=[],
+    install_requires=[
+        'parse',
+        'numpy',
+        'cached_property',
+    ],
     extras_require={
         'maestrowf': ['maestrowf'],
-        'best_candidate': ['pandas', 'numpy', 'scipy']
+        'best_candidate': ['pandas', 'scipy']
     },
     scripts=['bin/pgen_scisample.py']
 )

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -207,8 +207,16 @@ class TestScisampleList(unittest.TestCase):
                 X1: 20
             parameters:
                 X2: [5, 10]
-                X3: [5, 10]
-                X4: [5, 10]
+                X3:
+                    min: 5
+                    max: 10
+                    step: 5
+                X4: 5.0 to 10 by 5.0
+                X5: "[5.0:10.0:5]"
+                X6:
+                    start: 5
+                    stop: 10
+                    num_points: 2
             """
         sampler = new_sampler_from_yaml(yaml_text)
         self.assertTrue(isinstance(sampler, ListSampler))
@@ -218,21 +226,20 @@ class TestScisampleList(unittest.TestCase):
         self.assertEqual(len(samples), 2)
         for sample in samples:
             self.assertEqual(sample['X1'], 20)
-        self.assertEqual(samples[0]['X2'], 5)
-        self.assertEqual(samples[0]['X3'], 5)
-        self.assertEqual(samples[0]['X4'], 5)
-        self.assertEqual(samples[1]['X2'], 10)
-        self.assertEqual(samples[1]['X3'], 10)
-        self.assertEqual(samples[1]['X4'], 10)
+        for i in range(2, 7):
+            self.assertEqual(samples[0][f'X{i}'], 5)
+            self.assertEqual(samples[1][f'X{i}'], 10)
         sampler
         self.assertEqual(samples, 
-            [{'X1': 20, 'X2': 5, 'X3': 5, 'X4': 5}, 
-             {'X1': 20, 'X2': 10, 'X3': 10, 'X4': 10}])
+            [{'X1': 20, 'X2': 5, 'X3': 5, 'X4': 5, 'X5': 5, 'X6': 5}, 
+             {'X1': 20, 'X2': 10, 'X3': 10, 'X4': 10, 'X5': 10, 'X6': 10}])
         self.assertEqual(sampler.parameter_block, 
             {'X1': {'values': [20, 20], 'label': 'X1.%%'}, 
              'X2': {'values': [5, 10], 'label': 'X2.%%'}, 
              'X3': {'values': [5, 10], 'label': 'X3.%%'}, 
-             'X4': {'values': [5, 10], 'label': 'X4.%%'}})
+             'X4': {'values': [5, 10], 'label': 'X4.%%'}, 
+             'X5': {'values': [5, 10], 'label': 'X5.%%'}, 
+             'X6': {'values': [5, 10], 'label': 'X6.%%'}})
 
     def test_error(self):
         """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,63 @@
+"""
+Tests for utility functions.
+"""
+
+from scisample.utils import parse_parameters, parameter_list
+
+
+mylist = [1.0, 2.0, 3.0, 4.0, 5.0]
+
+def test_parameter_list_step():
+    """
+    When I request a parameter list using steps,
+    It should match the expected result.
+    """
+    assert parameter_list(start=1.0, stop=5.0, step=1.0) == mylist
+
+
+def test_parameter_list_points():
+    """
+    When I request a parameter list using number of points,
+    It should match the expected result.
+    """
+    assert parameter_list(start=1.0, stop=5.0, num_points=5) == mylist
+
+
+def test_list():
+    """
+    Given a list of points,
+    parse_parameters should return the same list.
+    """
+    assert parse_parameters(mylist) == mylist
+
+
+def test_dict_step():
+    """
+    Given a dict containing start, stop, and step,
+    parse_parameters should return the correct list.
+    """
+    assert parse_parameters({'start': 1.0, 'stop': 5.0, 'step': 1.0}) == mylist
+
+
+def test_dict_num_points():
+    """
+    Given a dict containing min, max, and num_points,
+    parse_parameters should return the correct list.
+    """
+    assert parse_parameters({'min': 1.0, 'max': 5.0, 'num_points': 5}) == mylist
+
+
+def test_str_range():
+    """
+    Given a string ``[start:stop:step]``,
+    parse_parameters should return the correct list.
+    """
+    assert parse_parameters("[1.0:5.0:1.0]") == mylist
+
+
+def test_str_by():
+    """
+    Given a string ``start to stop by step``,
+    parse_parameters should return the correct list.
+    """
+    assert parse_parameters("1.0 to 5.0 by 1.0") == mylist


### PR DESCRIPTION
Added options for specifying parameters for the `list` and  `cross_product` samplers:

```
X1:
    min: 5.0 # can also specify as start
    max: 10.0 # can also specify as stop
    step: 5 # can alternately specify num_points
X2: "[5:10:5]" # 5 to 10 by 5
X3: 5 to 10 by 5
```
