### PR TITLE
Patch Depreciated Method From Pandas Dataframe

### DIFF
--- a/scisample/base_sampler.py
+++ b/scisample/base_sampler.py
@@ -373,8 +373,5 @@ class BaseSampler(SamplerInterface):
                 sample_points.append(candidates[j])
                 new_sample_ids.append(j)
 
-        new_samples_df = pd.DataFrame(columns=df.keys().tolist())
-        for new_sample_id in new_sample_ids:
-            new_samples_df = new_samples_df.append(df.iloc[new_sample_id])
-
+        new_samples_df = df.iloc[new_sample_ids]
         self._samples = new_samples_df.to_dict(orient='records')


### PR DESCRIPTION
This MR updates the construction of `new_samples_df` on lines 343-345 in `scisample/base_sampler.py` to avoid the use of the dataframe's `append` method as this method was deprecated in Pandas version 1.4.0.

Ready for review.